### PR TITLE
Improve Voronoi transition smoothness

### DIFF
--- a/adr/0002-smooth-point-transition.md
+++ b/adr/0002-smooth-point-transition.md
@@ -1,0 +1,13 @@
+# ADR 0002: Smooth Voronoi point transitions
+
+## Status
+Accepted
+
+## Context
+Randomising a completely new set of Voronoi sample points every time the background hue changes makes each point jump across the canvas. The interpolation logic maps old points to these new random locations so positions and colours change abruptly despite the five second duration.
+
+## Decision
+Introduce a `perturbPoints` function that generates new targets by applying small random offsets to the currently rendered points while computing new colours. The update interval now calls `setTarget(perturbPoints(currentPoints, hue))` rather than `randomPoints(hue)`. Each point therefore moves only a short distance and keeps its index, allowing the existing interpolation to blend colours and positions smoothly.
+
+## Consequences
+Gradient updates no longer appear to jump. Cells drift gradually as their colours shift, preserving the smooth transition effect.

--- a/js/background.js
+++ b/js/background.js
@@ -85,6 +85,31 @@ void main() {
     return points;
   }
 
+  function perturbPoints(base, hue) {
+    const aspect = canvas.width / canvas.height;
+    const scale = Math.sqrt(aspect);
+    const width = Math.max(1, Math.round(SAMPLES * scale));
+    const height = Math.max(1, Math.round(SAMPLES / scale));
+    const num = width * height;
+    return base.map((p, idx) => {
+      const x = idx % width;
+      const y = Math.floor(idx / width);
+      const i = num - (height * y + x);
+      let h = hue + 120 * ((Math.round(Math.random() * 4 - 2) + x) / width +
+        (Math.round(Math.random() * 4 - 2) + y) / height) / 2;
+      if (h > 360) h -= 360;
+      const c = 80;
+      const l = 80 - 60 * ((Math.round(Math.random() * 4 - 2) + x) / width +
+        (Math.round(Math.random() * 4 - 2) + y) / height) / 2 + 20 * (i / num);
+      const rgb = d3.hcl(h, c, l).rgb();
+      return [
+        p[0] + (Math.random() * 0.1 - 0.05),
+        p[1] + (Math.random() * 0.1 - 0.05),
+        [rgb.r / 255, rgb.g / 255, rgb.b / 255]
+      ];
+    });
+  }
+
   function pointsFromImage(img) {
     const aspect = canvas.width / canvas.height;
     const scale = Math.sqrt(aspect);
@@ -201,7 +226,7 @@ void main() {
   }
 
   const changeInterval = setInterval(() => {
-    setTarget(randomPoints(Math.random() * 360));
+    setTarget(perturbPoints(currentPoints, Math.random() * 360));
   }, 10000);
 
   document.ondragover = e => {


### PR DESCRIPTION
## Summary
- document decision to preserve point order for smoother animation
- introduce `perturbPoints` helper
- update timer to use the new function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68456b4f5c248321a5ed9916451b2c83